### PR TITLE
Improve bluetooth teleop support

### DIFF
--- a/warthog_control/config/teleop.yaml
+++ b/warthog_control/config/teleop.yaml
@@ -5,8 +5,8 @@ joy_teleop:
     scale_linear_turbo: 1.0
     axis_angular: 0
     scale_angular: 2.4
-    enable_button: 0
-    enable_turbo_button: 2
+    enable_button: 4
+    enable_turbo_button: 5
   joy_node:
     deadzone: 0.1
     autorepeat_rate: 20

--- a/warthog_control/launch/teleop.launch
+++ b/warthog_control/launch/teleop.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
 
-  <arg name="joy_dev" default="/dev/input/js0" />
+  <arg name="joy_dev" default="$(optenv WARTHOG_JOY_DEV /dev/input/js0)" />
 
   <group ns="joy_teleop" if="$(optenv WARTHOG_JOY_TELEOP 0)">
     <rosparam command="load" file="$(find warthog_control)/config/teleop.yaml" />


### PR DESCRIPTION
This makes using teleop in Gazebo easier, as otherwise there's no exposed way to set the joy device for the control node.

Also change the enable buttons to be 4/5 (left/right shoulder buttons) to keep things consistent across platforms.