### PR TITLE
Add an envar to set the paint colour of the URDF

### DIFF
--- a/warthog_description/urdf/warthog.urdf.xacro
+++ b/warthog_description/urdf/warthog.urdf.xacro
@@ -29,7 +29,27 @@
 
   <xacro:property name="dummy_inertia" value="1e-09"/>
 
+  <!--
+    Optional paint colors.
+    Available colors:
+      - yellow (default)
+      - orange
+      - olive
+      - sand
+  -->
   <xacro:property name="warthog_color" value="$(optenv WARTHOG_COLOR yellow)" />
+  <xacro:if value="${warthog_color == 'yellow'}">
+    <xacro:property name="warthog_color_rgba" value="0.95 0.816 0.082 1.0" />
+  </xacro:if>
+  <xacro:if value="${warthog_color == 'orange'}">
+    <xacro:property name="warthog_color_rgba" value="1.0 0.48 0.0 1.0" />
+  </xacro:if>
+  <xacro:if value="${warthog_color == 'olive'}">
+    <xacro:property name="warthog_color_rgba" value="0.333 0.419 0.184 1.0" />
+  </xacro:if>
+  <xacro:if value="${warthog_color == 'sand'}">
+    <xacro:property name="warthog_color_rgba" value="0.86 0.75 0.54 1.0" />
+  </xacro:if>
 
   <xacro:macro name="wheel_inertia" params="m r h">
     <inertia ixx="${m*(3*r*r+h*h)/12}" ixy="0" ixz="0"
@@ -46,7 +66,6 @@
   <material name="dark_grey"><color rgba="0.2 0.2 0.2 1.0" /></material>
   <material name="light_grey"><color rgba="0.4 0.4 0.4 1.0" /></material>
   <material name="yellow"><color rgba="0.95 0.816 0.082 1.0" /></material>
-  <material name="olive_green"><color rgba="0.333 0.419 0.184 1.0" /></material>
   <material name="black"><color rgba="0.15 0.15 0.15 1.0" /></material>
   <material name="white"><color rgba="0.9 0.9 0.9 1.0" /></material>
   <material name="red"><color rgba="0.9 0.0 0.0 1.0" /></material>
@@ -199,12 +218,9 @@
         <geometry>
           <mesh filename="package://warthog_description/meshes/fenders.stl" />
         </geometry>
-        <xacro:if value="${warthog_color == 'yellow'}">
-          <material name="yellow"><color rgba="0.95 0.816 0.082 1.0" /></material>
-        </xacro:if>
-        <xacro:if value="${warthog_color == 'olive_green'}">
-          <material name="olive_green"><color rgba="0.333 0.419 0.184 1.0" /></material>
-        </xacro:if>
+        <material name="${warthog_color}">
+          <color rgba="${warthog_color_rgba}" />
+        </material>
       </visual>
       <visual>
         <origin xyz="0 ${side*-0.0244} 0" rpy="0 0 0"/>

--- a/warthog_description/urdf/warthog.urdf.xacro
+++ b/warthog_description/urdf/warthog.urdf.xacro
@@ -29,6 +29,8 @@
 
   <xacro:property name="dummy_inertia" value="1e-09"/>
 
+  <xacro:property name="warthog_color" value="$(optenv WARTHOG_COLOR yellow)" />
+
   <xacro:macro name="wheel_inertia" params="m r h">
     <inertia ixx="${m*(3*r*r+h*h)/12}" ixy="0" ixz="0"
              iyy="${m*r*r/2}" iyz="0"
@@ -44,6 +46,7 @@
   <material name="dark_grey"><color rgba="0.2 0.2 0.2 1.0" /></material>
   <material name="light_grey"><color rgba="0.4 0.4 0.4 1.0" /></material>
   <material name="yellow"><color rgba="0.95 0.816 0.082 1.0" /></material>
+  <material name="olive_green"><color rgba="0.333 0.419 0.184 1.0" /></material>
   <material name="black"><color rgba="0.15 0.15 0.15 1.0" /></material>
   <material name="white"><color rgba="0.9 0.9 0.9 1.0" /></material>
   <material name="red"><color rgba="0.9 0.0 0.0 1.0" /></material>
@@ -196,7 +199,12 @@
         <geometry>
           <mesh filename="package://warthog_description/meshes/fenders.stl" />
         </geometry>
-        <material name="yellow"><color rgba="0.95 0.816 0.082 1.0" /></material>
+        <xacro:if value="${warthog_color == 'yellow'}">
+          <material name="yellow"><color rgba="0.95 0.816 0.082 1.0" /></material>
+        </xacro:if>
+        <xacro:if value="${warthog_color == 'olive_green'}">
+          <material name="olive_green"><color rgba="0.333 0.419 0.184 1.0" /></material>
+        </xacro:if>
       </visual>
       <visual>
         <origin xyz="0 ${side*-0.0244} 0" rpy="0 0 0"/>


### PR DESCRIPTION
Since a good percentage of the Warthogs we sell aren't in the standard yellow, add an envar to change the material colour so the URDF matches the physical robot.
Supported colours in this PR are:
- yellow (default)
- olive
- orange
- sand (Mike wants a desert-camo pattern, but this is the closest I could get to that)