### PR TITLE
Add envars to set the reference coordinate of the GPS plugin

### DIFF
--- a/warthog_description/urdf/warthog.gazebo
+++ b/warthog_description/urdf/warthog.gazebo
@@ -37,8 +37,8 @@
       <frameId>base_link</frameId>
       <topicName>/navsat/fix</topicName>
       <velocityTopicName>/navsat/vel</velocityTopicName>
-      <referenceLatitude>49.9</referenceLatitude>
-      <referenceLongitude>8.9</referenceLongitude>
+      <referenceLatitude>$(optenv GAZEBO_WORLD_LAT 49.9)</referenceLatitude>
+      <referenceLongitude>$(optenv GAZEBO_WORLD_LON 8.9)</referenceLongitude>
       <referenceHeading>0</referenceHeading>
       <referenceAltitude>0</referenceAltitude>
       <drift>0.0001 0.0001 0.0001</drift>


### PR DESCRIPTION
Add GAZEBO_WORLD_{LAT|LON} envars to change the reference coordinate of the robot's integral GPS