### PR TITLE
added outdoornav enable variable and hardware kit selector for urdf

### DIFF
--- a/warthog_description/package.xml
+++ b/warthog_description/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>
+  <run_depend>cpr_onav_description</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>

--- a/warthog_description/urdf/warthog.urdf.xacro
+++ b/warthog_description/urdf/warthog.urdf.xacro
@@ -393,6 +393,16 @@
        default each one to off.-->
   <xacro:include filename="$(find warthog_description)/urdf/accessories.urdf.xacro" />
 
+  <!-- OutdoorNav -->
+  <xacro:arg name="outdoornav_enabled"       default="$(optenv OUTDOORNAV_ENABLED 0)" />
+  <xacro:arg name="outdoornav_configuration" default="$(optenv OUTDOORNAV_CONFIGURATION standard)" />
+
+  <!-- OutdoorNav URDF Config -->
+  <xacro:if value="$(arg outdoornav_enabled)">
+    <xacro:include filename="$(find cpr_onav_description)/urdf/outdoornav_description.urdf.xacro" />
+    <xacro:outdoornav_sensors outdoornav_configuration="$(arg outdoornav_configuration)" />
+  </xacro:if>
+
   <!-- Optional custom includes. -->
   <xacro:include filename="$(optenv WARTHOG_URDF_EXTRAS empty.urdf)" />
 


### PR DESCRIPTION
Added the option to extend the URDF with the OutdoorNav links. Including:

Starter Kit
Standard Kit
Custom
New dependency: cpr_onav_description