### PR TITLE
Remove robotNamespace in .gazebo file

### DIFF
--- a/warthog_description/urdf/warthog.gazebo
+++ b/warthog_description/urdf/warthog.gazebo
@@ -2,7 +2,6 @@
 <robot>
   <gazebo>
     <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-      <robotNamespace>/</robotNamespace>
       <legacyModeNS>true</legacyModeNS>
     </plugin>
   </gazebo>
@@ -16,7 +15,6 @@
 
   <gazebo>
     <plugin name="imu_controller" filename="libhector_gazebo_ros_imu.so">
-      <robotNamespace>/</robotNamespace>
       <updateRate>50.0</updateRate>
       <bodyName>imu_link</bodyName>
       <topicName>imu/data</topicName>
@@ -32,7 +30,6 @@
   <gazebo>
     <plugin name="gps_controller" filename="libhector_gazebo_ros_gps.so">
       <updateRate>20</updateRate>
-      <robotNamespace>/</robotNamespace>
       <bodyName>base_link</bodyName>
       <frameId>base_link</frameId>
       <topicName>/navsat/fix</topicName>


### PR DESCRIPTION
If robotNamespace is forced to be `/` in model's controllers, they won't work if they are included in any namespace. Removing them won't make any difference to the source code since any namespace is used.

This change allows to deploy and navigate several instances of the same robot in a world, e.g.:

```
<launch>
  <param name="robot_description"
    command="$(find robot_description)/urdf/robot.urdf.xacro" />

  <!-- BEGIN ROBOT 1-->
  <group ns="robot1">
    <include file="$(find pkg)/launch/robot.launch" />
  </group>

  <!-- BEGIN ROBOT 2-->
  <group ns="robot2">
    <include file="$(find pkg)/launch/robot.launch" />
  </group>
</launch>
```