### PR TITLE
Mod: Set 'publish_cmd' param to true in warthog_control/config

### DIFF
--- a/warthog_control/config/control.yaml
+++ b/warthog_control/config/control.yaml
@@ -12,6 +12,9 @@ warthog_velocity_controller:
   cmd_vel_timeout: 0.25
   velocity_rolling_window_size: 2
 
+  # Publish final output cmd_vel to /warthog_velocity_controller/cmd_vel_out
+  publish_cmd: true
+
   # Odometry fused with IMU is published by robot_localization, so
   # no need to publish a TF based on encoders alone.
   enable_odom_tf: false


### PR DESCRIPTION
- With this change the diff drive controller will output the final cmd_vel to /warthog_velocity_controller/cmd_vel_out after any filters are applied (e.g., speed/acceleration limits)